### PR TITLE
fix makefile for macOS Sequoia & Ubuntu 24.04.01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ USER=$(shell id -u -n)
 TIME=$(shell date)
 JR_HOME=jr
 
+ifndef XDG_DATA_DIRS
 ifeq ($(OS), Windows_NT)
 	detectedOS := Windows
 else
@@ -12,15 +13,35 @@ endif
 
 ifeq ($(detectedOS), Darwin)
 	JR_SYSTEM_DIR="$(HOME)/Library/Application Support"
-	JR_USER_DIR="$(HOME)/.local/share"
 endif
-ifeq ($(detectedOS), Linux)
+ifeq ($(detectedOS),  Linux)
 	JR_SYSTEM_DIR="$(HOME)/.config"
-	JR_USER_DIR="$(HOME)/.local/share"
 endif
 ifeq ($(detectedOS), Windows_NT)
 	JR_SYSTEM_DIR="$(LOCALAPPDATA)"
+endif
+else
+	JR_SYSTEM_DIR=$(XDG_DATA_DIRS)
+endif
+
+ifndef XDG_DATA_HOME
+ifeq ($(OS), Windows_NT)
+	detectedOS := Windows
+else
+	detectedOS := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
+endif
+
+ifeq ($(detectedOS), Darwin)
+	JR_USER_DIR="$(HOME)/.local/share"
+endif
+ifeq ($(detectedOS),  Linux)
+	JR_USER_DIR="$(HOME)/.local/share"
+endif
+ifeq ($(detectedOS), Windows_NT)
 	JR_USER_DIR="$(LOCALAPPDATA)" //@TODO
+endif
+else
+	JR_USER_DIR=$(XDG_DATA_HOME)
 endif
 
 hello:
@@ -42,11 +63,11 @@ generate:
 
 compile:
 	@echo "Compiling"
-	go build -v -ldflags="-X 'github.com/jrnd-io/jr/pkg/cmd.Version=$(VERSION)' \
+	go build -v -ldflags="-w -s -X 'github.com/jrnd-io/jr/pkg/cmd.Version=$(VERSION)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.GoVersion=$(GOVERSION)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildUser=$(USER)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildTime=$(TIME)'" \
-	-ldflags -s -o build/jr jr.go
+	-o build/jr jr.go
 
 run: compile
 	./build/jr

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ USER=$(shell id -u -n)
 TIME=$(shell date)
 JR_HOME=jr
 
-ifndef XDG_DATA_DIRS
 ifeq ($(OS), Windows_NT)
 	detectedOS := Windows
 else
@@ -13,35 +12,15 @@ endif
 
 ifeq ($(detectedOS), Darwin)
 	JR_SYSTEM_DIR="$(HOME)/Library/Application Support"
+	JR_USER_DIR="$(HOME)/.local/share"
 endif
-ifeq ($(detectedOS),  Linux)
+ifeq ($(detectedOS), Linux)
 	JR_SYSTEM_DIR="$(HOME)/.config"
+	JR_USER_DIR="$(HOME)/.local/share"
 endif
 ifeq ($(detectedOS), Windows_NT)
 	JR_SYSTEM_DIR="$(LOCALAPPDATA)"
-endif
-else
-	JR_SYSTEM_DIR=$(XDG_DATA_DIRS)
-endif
-
-ifndef XDG_DATA_HOME
-ifeq ($(OS), Windows_NT)
-	detectedOS := Windows
-else
-	detectedOS := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
-endif
-
-ifeq ($(detectedOS), Darwin)
-	JR_USER_DIR="$(HOME)/.local/share"
-endif
-ifeq ($(detectedOS),  Linux)
-	JR_USER_DIR="$(HOME)/.local/share"
-endif
-ifeq ($(detectedOS), Windows_NT)
 	JR_USER_DIR="$(LOCALAPPDATA)" //@TODO
-endif
-else
-	JR_USER_DIR=$(XDG_DATA_HOME)
 endif
 
 hello:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ USER=$(shell id -u -n)
 TIME=$(shell date)
 JR_HOME=jr
 
-ifndef XDG_DATA_DIRS
 ifeq ($(OS), Windows_NT)
 	detectedOS := Windows
 else
@@ -13,35 +12,15 @@ endif
 
 ifeq ($(detectedOS), Darwin)
 	JR_SYSTEM_DIR="$(HOME)/Library/Application Support"
+	JR_USER_DIR="$(HOME)/.local/share"
 endif
-ifeq ($(detectedOS),  Linux)
+ifeq ($(detectedOS), Linux)
 	JR_SYSTEM_DIR="$(HOME)/.config"
+	JR_USER_DIR="$(HOME)/.local/share"
 endif
 ifeq ($(detectedOS), Windows_NT)
 	JR_SYSTEM_DIR="$(LOCALAPPDATA)"
-endif
-else
-	JR_SYSTEM_DIR=$(XDG_DATA_DIRS)
-endif
-
-ifndef XDG_DATA_HOME
-ifeq ($(OS), Windows_NT)
-	detectedOS := Windows
-else
-	detectedOS := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
-endif
-
-ifeq ($(detectedOS), Darwin)
-	JR_USER_DIR="$(HOME)/.local/share"
-endif
-ifeq ($(detectedOS),  Linux)
-	JR_USER_DIR="$(HOME)/.local/share"
-endif
-ifeq ($(detectedOS), Windows_NT)
 	JR_USER_DIR="$(LOCALAPPDATA)" //@TODO
-endif
-else
-	JR_USER_DIR=$(XDG_DATA_HOME)
 endif
 
 hello:
@@ -67,7 +46,7 @@ compile:
 	-X 'github.com/jrnd-io/jr/pkg/cmd.GoVersion=$(GOVERSION)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildUser=$(USER)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildTime=$(TIME)'" \
-	-o build/jr jr.go
+	-ldflags -s -o build/jr jr.go
 
 run: compile
 	./build/jr


### PR DESCRIPTION
- macOS Sequoia 15.0.1 = error invalid signature
Add flags `-ldflags -s` to build as (https://github.com/golang/go/issues/19734)

> error after build without new flags:
> ![Screenshot 2024-10-28 alle 13 17 18](https://github.com/user-attachments/assets/783bac34-6d0a-475a-976e-2937133d60c9)

- Ubuntu 24.04.01 LTS = env XDG_DATA_DIRS is not empty
Generalized the definition of the JR_SYSTEM_DIR env variable
> ![Schermata del 2024-10-28 13-20-18](https://github.com/user-attachments/assets/ab895d33-7f11-4d44-982b-82cb39d4ee97)
