### PR TITLE
fix makefile: macOS error invalid signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ generate:
 
 compile:
 	@echo "Compiling"
-	go build -v -ldflags="-X 'github.com/jrnd-io/jr/pkg/cmd.Version=$(VERSION)' \
+	go build -v -ldflags="-s -w -X 'github.com/jrnd-io/jr/pkg/cmd.Version=$(VERSION)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.GoVersion=$(GOVERSION)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildUser=$(USER)' \
 	-X 'github.com/jrnd-io/jr/pkg/cmd.BuildTime=$(TIME)'" \


### PR DESCRIPTION
macOS Sequoia 15.0.1 = error invalid signature
Add flags -ldflags -s to build as (https://github.com/golang/go/issues/19734)
and -w flag to also strip DWARF symbols.

> error after build without new flags:
> ![image](https://github.com/user-attachments/assets/6c960b87-b57a-4e21-9244-af121a97de3e)
